### PR TITLE
Prime suspect page UI

### DIFF
--- a/app/(layout-components)/create-team-modal.tsx
+++ b/app/(layout-components)/create-team-modal.tsx
@@ -12,18 +12,28 @@ export const CreateTeamModal: React.FC<CreateTeamModalProps> = ({
   const user = useQuery(api.users.getFromSession);
   const createTeam = useMutation(api.teams.createFromSession);
   const [teamName, setTeamName] = useState("");
-  console.log("teamName: ", teamName);
+  const [error, setError] = useState("");
   const modalRef = useRef<HTMLInputElement | null>(null);
 
   const handleTeamNameInput = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setTeamName(e.target.value);
+    const newName = e.target.value;
+    if (newName.length <= 20) {
+      setTeamName(newName);
+      setError("");
+    } else {
+      setError("Team name is too long. Keep it under 20 characters.");
+    }
   };
 
   const handleCreateTeamSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (!user?._id) return;
 
-    // createTeam(teamName, loggedUser._id);
+    if (teamName.length > 20) {
+      setError("Team name is too long. Keep it under 20 characters.");
+      return;
+    }
+
     createTeam({ team_name: teamName, user_id: user._id });
     closeModal();
   };
@@ -56,6 +66,7 @@ export const CreateTeamModal: React.FC<CreateTeamModalProps> = ({
                 onChange={handleTeamNameInput}
                 ref={modalRef}
               />
+              {error && <p className="text-red-500 text-sm mt-2">{error}</p>}
             </div>
             <div className="modal-action">
               <button className="btn btn-primary text-lg" type="submit">

--- a/app/(layout-components)/ending-card.tsx
+++ b/app/(layout-components)/ending-card.tsx
@@ -1,47 +1,76 @@
-'use client'
+"use client";
 
-import React, { useEffect, useState } from 'react'
-import { useQuery, useMutation } from 'convex/react'
-
-import { api } from '@/convex/_generated/api'
+import React, { useEffect, useState } from "react";
+import { useQuery } from "convex/react";
+import { api } from "@/convex/_generated/api";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faTrophy, faTimesCircle } from "@fortawesome/free-solid-svg-icons";
 
 export const EndingCard = () => {
-  const [visible, setVisible] = useState(false)
-  const game = useQuery(api.game.getGameObject)
+  const [visible, setVisible] = useState(false);
+  const game = useQuery(api.game.getGameObject);
+  const guess = useQuery(api.guesses.getFromSessionByTeam);
+
+  const hardCodedGuess = {
+    suspect_id: "55zgs7cfqt63krxvcccggc6e9jmqg38",
+    suspect_name: "Myles",
+    weapon_id: "0x1",
+    weapon_name: "Chloroform",
+    location_id: "0x1",
+    location_name: "The Study",
+  };
+
+  const winningGuess = hardCodedGuess.suspect_id === game?.guilty_suspect_id;
 
   useEffect(() => {
     if (game) {
-      setVisible(game?.concluded)
+      setVisible(game?.concluded);
     }
-  }, [game])
+  }, [game]);
 
-  if (!game?.concluded || !visible) return null
+  if (!game?.concluded || !visible) return null;
 
   return (
-    <div className='BLUR_SHADE fixed top-0 w-screen h-screen bg-red-800/50 backdrop-blur z-[1000] flex flex-col items-center justify-center'>
-      <div className='card w-5/6 bg-base-100 shadow-xl'>
-        <figure>
-          <img src='/den.webp' alt='Shoes' />
-        </figure>
-        <div className='card-body'>
-          <h2 className='card-title'>
-            <span>And the murderer is... </span>
-            <span className='text-red-500'>{game.guilty_suspect_name}!</span>
+    <div className="fixed inset-0 flex items-center justify-center p-2 bg-red-800 bg-opacity-50 backdrop-blur md:backdrop-blur-lg z-50">
+      <div className="w-full max-w-2xl bg-base-100 shadow-xl rounded-lg overflow-y-auto relative mx-2 md:mx-auto my-2 h-[85vh]">
+        <img
+          src="/den.webp"
+          alt="Shoes"
+          className="w-full object-cover h-1/3 md:h-1/2"
+        />
+        <div className="p-6">
+          <h2 className="text-2xl font-semibold mb-5 text-center">
+            And the murderer is...
+            <div className="text-red-600 mt-2">{game.guilty_suspect_name}!</div>
           </h2>
-          <p>
-            Despite his charismatic and charming persona, had a hidden motive.
-            Đen Vâu had discovered Myles&#39;s involvement in a past scandal
-            that could have ruined his reputation as a language teacher. Fearing
-            the exposure of this secret, Myles used chloroform to subdue Đen Vâu
-            during the party, strangled him, then put poison in his whiskey
-            after the murder in an attempt to frame his wife (whom he had been
-            quarreling with lately).
+          {winningGuess ? (
+            <div className="text-green-500 font-bold text-2xl flex items-center justify-center gap-3">
+              <FontAwesomeIcon icon={faTrophy} size="2x" />
+              Congratulations! You solved the murder!
+            </div>
+          ) : (
+            <div className="text-red-500 font-bold text-2xl flex items-center justify-center gap-3">
+              <FontAwesomeIcon icon={faTimesCircle} size="2x" />
+              Unfortunately, you did not solve the murder. Better luck next
+              time!
+            </div>
+          )}
+          <p className="mt-4 leading-relaxed text-justify">
+            {" "}
+            {/* Added margin-top and improved line-height */}
+            Despite his charismatic and charming persona, Myles had a hidden
+            motive. Đen Vâu had discovered Myles&#39;s involvement in a past
+            scandal that could have ruined his reputation as a language teacher.
+            Fearing the exposure of this secret, Myles used chloroform to subdue
+            Đen Vâu during the party, strangled him, then put poison in his
+            whiskey after the murder in an attempt to frame his wife (whom he
+            had been quarreling with lately).
           </p>
-          <div className='card-actions justify-end'>
-            <p className='italic'>Thanks for playing!</p>
+          <div className="flex flex-col items-center mt-6">
+            <p className="italic mb-3">Thanks for playing!</p>
             <button
               onClick={() => setVisible(false)}
-              className='btn btn-primary'
+              className="btn btn-primary mt-2"
             >
               Close
             </button>
@@ -49,5 +78,5 @@ export const EndingCard = () => {
         </div>
       </div>
     </div>
-  )
-}
+  );
+};

--- a/app/(layout-components)/team-info.tsx
+++ b/app/(layout-components)/team-info.tsx
@@ -30,9 +30,8 @@ export const TeamInfo: React.FC = () => {
     <div className="flex flex-col gap-4 w-full p-4 bg-slate-800 rounded-lg">
       <h2 className="text-white text-2xl font-bold">Team Details</h2>
 
-      <div className="text-white">
+      <div className="text-white overflow-hidden">
         <h3 className="text-xl font-semibold">Team Name: {team?.team_name}</h3>
-        <p>Membership: {displayedTeammates?.length}/10</p>
         <p>Captain: {captain?.name}</p>
       </div>
       <div
@@ -40,7 +39,9 @@ export const TeamInfo: React.FC = () => {
         onClick={toggleOpen}
       >
         <h3 className="text-white text-lg font-semibold ml-2">
-          {user?.is_captain ? "Manage Team" : "See Teammates"}
+          {user?.is_captain
+            ? `Manage Team (${teammates?.length}/10)`
+            : `See Teammates (${teammates?.length}/10)`}
         </h3>
         <span className="text-lg transform transition-transform duration-300 mr-2">
           {!isOpen ? "+" : "-"}


### PR DESCRIPTION
this evolved into:
1. refactor profile ui to fix the overly long team names and player names.. specifically, i added error handling and a check for team names longer than 20 chars in team creation and applied additional styling to profile components to display things nicely (hopefully). I also consolidated the number of players on team with the show teammates/manage team toggle for a cleaner look. 
2. test hard coded teamGuess to verify that a success message is displayed on the end of game card and it looks nice and responsive.. inversely, the sorry, you did not solve message also displays nicely and i made sure to distinguish with colors and icons. end of game modal should also be visible on all mobile devices nice with slight tweak to vh . 
3. pending guess obj from backend, the ui looks good but may require some adjustments following guess obj return. i logged every step of the createFromSession and it looks like team might be missing a guess attribute that the error is alluding to or something? wasnt sure if that was just work in progress on your end so i didnt start writing too much code in the guesses convex page. Im down to look into it in the morning though