### PR TITLE
Team player modal refactor

### DIFF
--- a/app/(context)/_providers.tsx
+++ b/app/(context)/_providers.tsx
@@ -3,12 +3,15 @@ import { ClerkConvexProvider } from "./clerk-convex.context";
 // import { GameProvider } from "./game.context";
 import { SuspectProvider } from "./suspect.context";
 // import { UserProvider } from './user.context'
+import { ModalProvider } from "./modal.context";
 
 export const Providers = ({ children }: { children: React.ReactNode }) => {
   return (
-    <ClerkConvexProvider>
+    <ModalProvider>
+      <ClerkConvexProvider>
         <SuspectProvider>{children}</SuspectProvider>
-    </ClerkConvexProvider>
+      </ClerkConvexProvider>
+    </ModalProvider>
   );
 };
 

--- a/app/(context)/modal.context.tsx
+++ b/app/(context)/modal.context.tsx
@@ -1,0 +1,42 @@
+// modalContext.tsx
+"use client";
+
+import { createContext, useContext, ReactNode, useState } from "react";
+
+export enum ModalType {
+  JOIN = "join",
+  CREATE = "create",
+  ADD = "add",
+  LEAVE = "leave",
+  NONE = "none",
+}
+
+type ModalContextType = {
+  modalType: ModalType;
+  showModal: (type: ModalType) => void;
+  closeModal: () => void;
+};
+
+const ModalContext = createContext<ModalContextType | undefined>(undefined);
+
+export const useModal = () => {
+  const context = useContext(ModalContext);
+  if (!context) {
+    throw new Error("useModal must be used within ModalProvider");
+  }
+  return context;
+};
+export const ModalProvider: React.FC<{ children: ReactNode }> = ({
+  children,
+}) => {
+  const [modalType, setModalType] = useState<ModalType>(ModalType.NONE);
+
+  const showModal = (type: ModalType) => setModalType(type);
+  const closeModal = () => setModalType(ModalType.NONE);
+
+  return (
+    <ModalContext.Provider value={{ modalType, showModal, closeModal }}>
+      {children}
+    </ModalContext.Provider>
+  );
+};

--- a/app/(layout-components)/add-member-modal.tsx
+++ b/app/(layout-components)/add-member-modal.tsx
@@ -1,6 +1,9 @@
+"use client";
+
 import React from "react";
 import { api } from "@/convex/_generated/api";
 import { useQuery, useMutation } from "convex/react-internal";
+import { ModalWrapper } from "./modal-wrapper";
 
 interface AddMemberModalProps {
   closeModal: () => void;
@@ -36,9 +39,9 @@ export const AddMemberModal: React.FC<AddMemberModalProps> = ({
   console.log("invitedUserIds: ", invitedUserIds);
 
   return (
-    <div className="flex flex-col items-center justify-start h-full bg-black !fixed w-screen h-screen z-10 inset-0 p-4">
-      {user && teamId && (
-        <div className="modal-box bg-gray-800 rounded-lg shadow-2xl p-6 w-full max-w-md mt-20 relative">
+    <ModalWrapper>
+      {teamId && user && (
+        <div>
           <button
             className="btn btn-sm btn-circle btn-ghost absolute top-2 right-2 p-2"
             onClick={closeModal}
@@ -54,7 +57,7 @@ export const AddMemberModal: React.FC<AddMemberModalProps> = ({
               <div>Loading...</div>
             </div>
           ) : (
-            <ul className="flex-col gap-2 sm:gap-4 w-full overflow-y-auto">
+            <ul className="max-h-[60vh] overflow-y-auto">
               {teamInvites &&
                 usersNotCurrentlyOnTeam?.map((userToInvite: any) => (
                   <li
@@ -104,6 +107,6 @@ export const AddMemberModal: React.FC<AddMemberModalProps> = ({
           )}
         </div>
       )}
-    </div>
+    </ModalWrapper>
   );
 };

--- a/app/(layout-components)/create-team-modal.tsx
+++ b/app/(layout-components)/create-team-modal.tsx
@@ -1,6 +1,9 @@
+"use client";
+
 import React, { useState, useRef, useEffect } from "react";
 import { api } from "@/convex/_generated/api";
 import { useQuery, useMutation } from "convex/react-internal";
+import { ModalWrapper } from "./modal-wrapper";
 
 interface CreateTeamModalProps {
   closeModal: () => void;
@@ -43,9 +46,9 @@ export const CreateTeamModal: React.FC<CreateTeamModalProps> = ({
   }
 
   return (
-    <div className="flex flex-col items-center justify-start h-full bg-black !fixed w-screen h-screen z-10 inset-0 p-4">
+    <ModalWrapper>
       {user && (
-        <div className="modal-box bg-gray-800 rounded-lg shadow-2xl p-6 w-full max-w-md mt-20 relative">
+        <div>
           <button
             className="btn btn-sm btn-circle btn-ghost absolute right-2 top-2"
             onClick={closeModal}
@@ -53,29 +56,31 @@ export const CreateTeamModal: React.FC<CreateTeamModalProps> = ({
             &times;
           </button>
           <h3 className="font-bold text-xl mb-4">Create a Team</h3>
-          <form onSubmit={handleCreateTeamSubmit}>
-            <div className="form-control w-full mb-4">
-              <label className="label text-lg mb-2">
-                <span className="label-text">What is your team name?</span>
-              </label>
-              <input
-                type="text"
-                placeholder="Team Name"
-                value={teamName}
-                className="input input-bordered w-full text-lg"
-                onChange={handleTeamNameInput}
-                ref={modalRef}
-              />
-              {error && <p className="text-red-500 text-sm mt-2">{error}</p>}
-            </div>
-            <div className="modal-action">
-              <button className="btn btn-primary text-lg" type="submit">
-                Create Team
-              </button>
-            </div>
-          </form>
+          <div>
+            <form onSubmit={handleCreateTeamSubmit}>
+              <div className="form-control w-full mb-4">
+                <label className="label text-lg mb-2">
+                  <span className="label-text">What is your team name?</span>
+                </label>
+                <input
+                  type="text"
+                  placeholder="Team Name"
+                  value={teamName}
+                  className="input input-bordered w-full text-lg"
+                  onChange={handleTeamNameInput}
+                  ref={modalRef}
+                />
+                {error && <p className="text-red-500 text-sm mt-2">{error}</p>}
+              </div>
+              <div className="modal-action">
+                <button className="btn btn-primary text-lg" type="submit">
+                  Create Team
+                </button>
+              </div>
+            </form>
+          </div>
         </div>
       )}
-    </div>
+    </ModalWrapper>
   );
 };

--- a/app/(layout-components)/join-team-modal.tsx
+++ b/app/(layout-components)/join-team-modal.tsx
@@ -1,6 +1,9 @@
+"use client";
+
 import React from "react";
 import { api } from "@/convex/_generated/api";
 import { useQuery, useMutation } from "convex/react-internal";
+import { ModalWrapper } from "./modal-wrapper";
 
 interface JoinTeamModalProps {
   closeModal: () => void;
@@ -54,25 +57,23 @@ export const JoinTeamModal: React.FC<JoinTeamModalProps> = ({ closeModal }) => {
   }
 
   return (
-    <div className="flex flex-col items-center justify-start h-full bg-black !fixed w-screen h-screen z-10 inset-0 p-4">
-      <div className="modal-box bg-gray-800 rounded-lg shadow-2xl p-6 w-full max-w-md mt-20">
-        <button
-          className="btn btn-sm btn-circle btn-ghost absolute top-2 right-2 p-2"
-          onClick={closeModal}
-        >
-          &times;
-        </button>
-        <h3 className="font-bold text-xl mb-4">Available Teams</h3>
-        {teams && user && requests ? (
-          <ul className="flex-col gap-4 w-full overflow-y-auto">
-            {teams?.map(renderTeam)}
-          </ul>
-        ) : (
-          <div className="flex items-left justify-left w-full">
-            <div>Loading...</div>{" "}
-          </div>
-        )}
-      </div>
-    </div>
+    <ModalWrapper>
+      <button
+        className="btn btn-sm btn-circle btn-ghost absolute top-2 right-2 p-2"
+        onClick={closeModal}
+      >
+        &times;
+      </button>
+      <h3 className="font-bold text-xl mb-4">Available Teams</h3>
+      {teams && user && requests ? (
+        <ul className="max-h-[50vh] overflow-y-auto">
+          {teams?.map(renderTeam)}
+        </ul>
+      ) : (
+        <div className="flex items-left justify-left w-full">
+          <div>Loading...</div>{" "}
+        </div>
+      )}
+    </ModalWrapper>
   );
 };

--- a/app/(layout-components)/leave-team-modal.tsx
+++ b/app/(layout-components)/leave-team-modal.tsx
@@ -1,6 +1,9 @@
+"use client";
+
 import React from "react";
 import { api } from "@/convex/_generated/api";
 import { useQuery, useMutation } from "convex/react-internal";
+import { ModalWrapper } from "./modal-wrapper";
 
 interface LeaveTeamModalProps {
   closeModal: () => void;
@@ -22,46 +25,37 @@ export const LeaveTeamModal: React.FC<LeaveTeamModalProps> = ({
   console.log("team: ", team);
   console.log("user: ", user);
 
-  const renderLeaveTeam = () => {
-    return (
-      <div className="flex flex-col items-center justify-start h-full bg-black !fixed w-screen h-screen z-10 inset-0 p-4">
-        {teamId && userId && (
-          <div className="modal-box bg-gray-800 rounded-lg shadow-2xl p-6 w-full max-w-md mt-20 relative">
-            {" "}
-            {/* Added relative for the close button's absolute positioning */}
-            <button
-              className="btn btn-sm btn-circle btn-ghost absolute right-2 top-2"
-              onClick={closeModal}
-            >
-              &times;
-            </button>
-            <h3 className="font-bold text-xl mb-4 w-[90%]">
-              Are you sure that you want to leave your team?
-            </h3>
-            <div className="modal-action">
-              <button
-                className="btn btn-primary w-full"
-                onClick={() => {
-                  leaveTeam({ user_id: userId, team_id: teamId });
-                  closeModal();
-                }}
-              >
-                Leave Team
-              </button>
-            </div>
-          </div>
-        )}
-      </div>
-    );
-  };
-
   if (!teamId || !userId) {
     return null;
   }
 
   return (
-    <div className="flex flex-col items-center justify-start h-full bg-black !fixed w-screen h-screen z-10 inset-0 p-4">
-      {renderLeaveTeam()}
-    </div>
+    <ModalWrapper>
+      {teamId && userId && (
+        <div>
+          {/* Added relative for the close button's absolute positioning */}
+          <button
+            className="btn btn-sm btn-circle btn-ghost absolute right-2 top-2"
+            onClick={closeModal}
+          >
+            &times;
+          </button>
+          <h3 className="font-bold text-xl mb-4 w-[90%]">
+            Are you sure that you want to leave your team?
+          </h3>
+          <div className="modal-action">
+            <button
+              className="btn btn-primary w-full"
+              onClick={() => {
+                leaveTeam({ user_id: userId, team_id: teamId });
+                closeModal();
+              }}
+            >
+              Leave Team
+            </button>
+          </div>
+        </div>
+      )}
+    </ModalWrapper>
   );
 };

--- a/app/(layout-components)/modal-wrapper.tsx
+++ b/app/(layout-components)/modal-wrapper.tsx
@@ -1,0 +1,24 @@
+import React, { useEffect } from "react";
+
+interface ModalWrapperProps {
+  children: React.ReactNode;
+}
+
+export const ModalWrapper: React.FC<ModalWrapperProps> = ({ children }) => {
+  useEffect(() => {
+    // Disable scrolling on the body by setting overflow to hidden
+    document.body.style.overflow = "hidden";
+
+    // Re-enable scrolling when the modal is closed or the component is unmounted
+    return () => {
+      document.body.style.overflow = "auto";
+    };
+  }, []);
+  return (
+    <div className="fixed top-0 left-0 right-0 bottom-0 z-50 flex items-start justify-center bg-black overflow-y-hidden p-4">
+      <div className="relative p-6 bg-slate-800 rounded-lg shadow-xl max-w-md w-full mt-20 overflow-y-hidden">
+        {children}
+      </div>
+    </div>
+  );
+};

--- a/app/(layout-components)/render-modals.tsx
+++ b/app/(layout-components)/render-modals.tsx
@@ -1,0 +1,29 @@
+"use client"; // This indicates that the component is intended to be client-side only.
+import React from "react";
+import { useModal, ModalType } from "../(context)/modal.context";
+import { JoinTeamModal } from "./join-team-modal";
+import { CreateTeamModal } from "./create-team-modal";
+import { AddMemberModal } from "./add-member-modal";
+import { LeaveTeamModal } from "./leave-team-modal";
+
+export function ModalsRenderer() {
+  const { modalType, closeModal } = useModal();
+
+  if (modalType === ModalType.JOIN) {
+    return <JoinTeamModal closeModal={closeModal} />;
+  }
+
+  if (modalType === ModalType.CREATE) {
+    return <CreateTeamModal closeModal={closeModal} />;
+  }
+
+  if (modalType === ModalType.ADD) {
+    return <AddMemberModal closeModal={closeModal} />;
+  }
+
+  if (modalType === ModalType.LEAVE) {
+    return <LeaveTeamModal closeModal={closeModal} />;
+  }
+
+  return null; // No modal to render.
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,12 +1,13 @@
 import { ReactNode } from "react";
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
-import NextTopLoader from 'nextjs-toploader'
+import NextTopLoader from "nextjs-toploader";
 
 import { Providers } from "./(context)/_providers";
 import { Navbar } from "./(layout-components)/navbar";
 import { BottomNav } from "./(layout-components)/bottom-nav";
 import { ToastHandler } from "./(layout-components)/toast-handler";
+import { ModalsRenderer } from "./(layout-components)/render-modals";
 
 import "./globals.css";
 import { EndingCard } from "./(layout-components)/ending-card";
@@ -18,7 +19,6 @@ export const metadata: Metadata = {
   description: "A fun murder mystery game to prep students for IELTS!",
 };
 
-
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
@@ -29,12 +29,20 @@ export default function RootLayout({ children }: { children: ReactNode }) {
           <NextTopLoader />
           <Navbar />
           <EndingCard />
-          <main className='py-24 pb-32 w-[90%] min-h-screen h-auto relative w-full flex flex-col items-center z-10'>
-            <div className='content-wrapper h-auto w-[90%] z-10'>{children}</div>
+          <main className="py-24 pb-32 w-[90%] min-h-screen h-auto relative w-full flex flex-col items-center z-10">
+            <div className="content-wrapper h-auto w-[90%] z-10">
+              {children}
+            </div>
           </main>
           <ToastHandler />
           <BottomNav />
-          <img src="/site-bg.png" alt="darkened murder evidence board" className="fixed inset-0 full" />
+          <img
+            src="/site-bg.png"
+            alt="darkened murder evidence board"
+            className="fixed inset-0 full"
+          />
+
+          <ModalsRenderer />
         </Providers>
       </body>
     </html>

--- a/app/user-profile/page.tsx
+++ b/app/user-profile/page.tsx
@@ -5,6 +5,7 @@ import { api } from "@/convex/_generated/api";
 import { useConvexAuth, useMutation, useQuery } from "convex/react-internal";
 import { useAuth, useSession } from "@clerk/nextjs";
 import { usePrevious } from "../(hooks)/utility/usePrevious";
+import { useModal, ModalType } from "../(context)/modal.context";
 
 import { TeamSelection } from "../(layout-components)/team-selection";
 import { JoinTeamModal } from "../(layout-components)/join-team-modal";
@@ -18,22 +19,23 @@ import { NotificationToast } from "../(layout-components)/notification-toast";
 const UserProfilePage = () => {
   const { isSignedIn, isLoaded } = useSession();
   const user = useQuery(api.users.getFromSession);
+  const { showModal } = useModal();
 
-  enum ModalType {
-    JOIN = "join",
-    CREATE = "create",
-    ADD = "add",
-    LEAVE = "leave",
-    NONE = "none",
-  }
+  // enum ModalType {
+  //   JOIN = "join",
+  //   CREATE = "create",
+  //   ADD = "add",
+  //   LEAVE = "leave",
+  //   NONE = "none",
+  // }
 
-  const [modalType, setModalType] = useState<ModalType>(ModalType.NONE);
-  console.log("modalType: ", modalType);
-  const showJoinModal = () => setModalType(ModalType.JOIN);
-  const showCreateModal = () => setModalType(ModalType.CREATE);
-  const showAddModal = () => setModalType(ModalType.ADD);
-  const showLeaveModal = () => setModalType(ModalType.LEAVE);
-  const closeModal = () => setModalType(ModalType.NONE);
+  // const [modalType, setModalType] = useState<ModalType>(ModalType.NONE);
+  // console.log("modalType: ", modalType);
+  // const showJoinModal = () => setModalType(ModalType.JOIN);
+  // const showCreateModal = () => setModalType(ModalType.CREATE);
+  // const showAddModal = () => setModalType(ModalType.ADD);
+  // const showLeaveModal = () => setModalType(ModalType.LEAVE);
+  // const closeModal = () => setModalType(ModalType.NONE);
 
   if (!isSignedIn || !isLoaded || !user) {
     return (
@@ -48,23 +50,11 @@ const UserProfilePage = () => {
       <UserInfoSection />
       {user.has_team && <TeamInfo />}
       <TeamSelection
-        showJoinModal={showJoinModal}
-        showCreateModal={showCreateModal}
-        showAddModal={showAddModal}
-        showLeaveModal={showLeaveModal}
+        showJoinModal={() => showModal(ModalType.JOIN)}
+        showCreateModal={() => showModal(ModalType.CREATE)}
+        showAddModal={() => showModal(ModalType.ADD)}
+        showLeaveModal={() => showModal(ModalType.LEAVE)}
       />
-      {modalType === ModalType.JOIN && (
-        <JoinTeamModal closeModal={closeModal} />
-      )}
-      {modalType === ModalType.CREATE && (
-        <CreateTeamModal closeModal={closeModal} />
-      )}
-      {modalType === ModalType.ADD && (
-        <AddMemberModal closeModal={closeModal} />
-      )}
-      {modalType === ModalType.LEAVE && (
-        <LeaveTeamModal closeModal={closeModal} />
-      )}
 
       <NotificationsSection />
     </div>


### PR DESCRIPTION
Refactor the way modals are triggered, styled, and displayed in app. 
1). Migrate modal render from user-profile to root layout to ensure full page overlay on render
2). Create Modal context to centralize modal state and types and allow for easier access across app
3). Abstract modal render logic to separate render-modals component and import relevant state and types from modal context
4). Abstract modal backdrop and container style to new modal-wrapper component and better ensure uniform style and structure across modals
5). import modal wrappers to the different modal content components(joinTeamModal, createTeamModal, etc) and check for correct style and structure for mobile first display preferences. 
6). Adjust scroll so that backdrop scroll is disabled and scroll is automatically set for modal contents like players or teams when necessary